### PR TITLE
Use `quilt_rs`

### DIFF
--- a/plugins/nf-quilt/src/main/nextflow/quilt/jep/Quilt.java
+++ b/plugins/nf-quilt/src/main/nextflow/quilt/jep/Quilt.java
@@ -1,0 +1,13 @@
+package nextflow.quilt.jep;
+
+public class Quilt {
+    public static native String commit(String domain, String namespace, String message);
+
+    public static native String install(String domain, String uri);
+
+    public static native String push(String domain, String namespace);
+
+    static {
+        System.load("/home/fiskus/reps/quilt-rs/target/debug/libquilt_rs.so");
+    }
+}

--- a/plugins/nf-quilt/src/main/nextflow/quilt/jep/QuiltPackage.groovy
+++ b/plugins/nf-quilt/src/main/nextflow/quilt/jep/QuiltPackage.groovy
@@ -186,9 +186,9 @@ class QuiltPackage {
     }
 
     // https://docs.quiltdata.com/v/version-5.0.x/examples/gitlike#install-a-package
-    Manifest push(String msg = 'update', Map meta = [:]) {
+    String push(String msg = 'update', Map meta = [:]) {
         try {
-            Manifest manifest = QuiltLocal.DOMAIN.push(this, "nf-quilt:${today()}-${msg}", meta)
+            String manifest = QuiltLocal.DOMAIN.push(this, "nf-quilt:${today()}-${msg}", meta)
             log.debug("pushed[${this.parsed}]: ${manifest}")
             return manifest
         } catch (Exception e) {

--- a/plugins/nf-quilt/src/main/nextflow/quilt/nio/QuiltPath.groovy
+++ b/plugins/nf-quilt/src/main/nextflow/quilt/nio/QuiltPath.groovy
@@ -73,10 +73,13 @@ final class QuiltPath implements Path, Comparable {
         return sub_paths()
     }
 
+    // Path to the installed manifest?
+    // Ex. `.quilt/installed/foo/bar/hash1234`?
     Path localPath() {
-        Path pkgPath = pkg().packageDest()
+        QuiltPackage p = pkg()
+        Path pkgPath = p.packageDest()
         assert pkgPath
-        return Paths.get(pkgPath.toUriString(), sub_paths())
+        return pkgPath.resolve(p.hash)
     }
 
     boolean deinstall() {


### PR DESCRIPTION
On top of https://github.com/quiltdata/nf-quilt/pull/202

You need fresh version of https://github.com/quiltdata/quilt-rs/pull/187: there are slightly different methods names, because `Quilt` now is `Java_nextflow_quilt_jep_Quilt`

1. Go to `quilt_rs` repo, `git pull` latest change of the `jni` branch. Then `cargo build`. It will build `libquilt_rs.so` in `target/debug`
2. Back to this repo
3. `cd plugins/nf-quilt/src/main/nextflow/quilt/jep`
4. Change path in `System.load` in `Quilt.java` to the correct location of the `libquilt_rs.so`
5. `javac Quilt.java`. It will compile `Quilt.class`
6. Then you can run tests: `cd - && make check`

Tests are failing because they rely on one directories' structure, but `quilt_rs` uses different directories. I couldn't manage to fix them.