### PR TITLE
Release 1.0.0 (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## [0.9.2] 2026-04-29
+## [1.0.0] 2026-04-29
 
+- First release published to the [Nextflow Plugin Registry](https://registry.nextflow.io)
 - Use "package" as default prefix
 - Modernize main*.nf files
 - Fix Jackson serialization of `java.time.OffsetDateTime` from Nextflow 24.10+ workflow metadata (#321)

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -8,14 +8,14 @@ Registry](https://registry.nextflow.io), users can install it directly via
 `NXF_PLUGINS_TEST_REPOSITORY` override is required.
 
 ```bash
-nextflow run main.nf -plugins nf-quilt@0.9.2
+nextflow run main.nf -plugins nf-quilt@1.0.0
 ```
 
 To pin the plugin in `nextflow.config`:
 
 ```groovy
 plugins {
-    id 'nf-quilt@0.9.2'
+    id 'nf-quilt@1.0.0'
 }
 ```
 
@@ -71,14 +71,14 @@ via `-plugins nf-quilt@<version>`. For example, with a standard `nf-core`
 pipeline like `sarek`:
 
 ```bash
-nextflow run nf-core/sarek -profile test,docker -plugins nf-quilt@0.9.2 \
+nextflow run nf-core/sarek -profile test,docker -plugins nf-quilt@1.0.0 \
   --outdir "quilt+s3://bucket#package=nf-quilt/sarek"
 ```
 
 Or with a local pipeline:
 
 ```bash
-nextflow run ./main.nf -profile standard -plugins nf-quilt@0.9.2 \
+nextflow run ./main.nf -profile standard -plugins nf-quilt@1.0.0 \
   --outdir "quilt+s3://bucket#package=test/hurdat"
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 // Plugin version: bump here to release a new version.
 // Keep in sync with any references in CHANGELOG / README until the 1.0.0 release.
-version = '0.9.2'
+version = '1.0.0'
 group = 'io.nextflow'
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ plugins {
 }
 
 // Plugin version: bump here to release a new version.
-// Keep in sync with any references in CHANGELOG / README until the 1.0.0 release.
 version = '1.0.0'
 group = 'io.nextflow'
 


### PR DESCRIPTION
## Summary

First release published to the [Nextflow Plugin Registry](https://registry.nextflow.io). Bumps the plugin version to `1.0.0`, consolidating the unpublished `0.9.2` intermediate into the registry-migration release.

This is the final PR in the migration tracked by #323. It bundles three previously-merged PRs:

- #322 — Jackson `OffsetDateTime` serialization fix for Nextflow 24.10+
- #324 — Migrate to the new `io.nextflow.nextflow-plugin` Gradle build system
- #327 — Docs refresh + restore JaCoCo 70% line-coverage gate

## Changes

- `build.gradle`: `version = '0.9.2'` -> `'1.0.0'`
- `CHANGELOG.md`: rename `[0.9.2]` section to `[1.0.0]` and add note about Nextflow Plugin Registry as the publishing channel
- `README-DEV.md`: bump example `nf-quilt@0.9.2` references to `@1.0.0`

The `dest-1.0.0` test package has been pre-published to `s3://udp-spec` so `QuiltPkgTest > should confirm contents of dest URI` passes in CI.

## Post-merge manual steps (human)

The actual registry publish is intentionally NOT automated in this PR:

1. `git tag 1.0.0 && git push origin 1.0.0`
2. `export NPR_API_KEY=... && ./gradlew releasePlugin`
3. Verify the plugin appears on https://registry.nextflow.io
4. Close #321 with the registry URL

## Test plan

- [x] `./gradlew test` passes
- [x] `./gradlew check` passes (JaCoCo gate satisfied)
- [x] `./gradlew packagePlugin` produces `build/distributions/nf-quilt-1.0.0.zip`
- [x] `make pkg-test WRITE_BUCKET=udp-spec` published `nf-quilt/dest-1.0.0` to `udp-spec`
- [ ] CI green

Closes #323
Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the plugin version from `0.9.2` to `1.0.0` across `build.gradle`, `CHANGELOG.md`, and `README-DEV.md` in preparation for the first publish to the Nextflow Plugin Registry. All `0.9.2` references have been consistently updated and no stale occurrences remain in the repository.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are purely a version bump with no functional code modifications.

Only P2 finding (stale comment in build.gradle); no logic, security, or correctness issues present.

No files require special attention beyond the minor stale comment in build.gradle line 17.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| build.gradle | Version bumped from 0.9.2 to 1.0.0; stale "until the 1.0.0 release" comment left in place (P2) |
| CHANGELOG.md | Section heading renamed from [0.9.2] to [1.0.0]; registry publication note prepended — no issues found |
| README-DEV.md | Four nf-quilt version references updated from 0.9.2 to 1.0.0 in example commands — no issues found |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["build.gradle\nversion = '1.0.0'"] --> B["./gradlew packagePlugin\nnf-quilt-1.0.0.zip"]
    B --> C["git tag 1.0.0\ngit push origin 1.0.0"]
    C --> D["./gradlew releasePlugin\nNPR_API_KEY set"]
    D --> E["Nextflow Plugin Registry\nregistry.nextflow.io"]
    F["CHANGELOG.md\n1.0.0 section"] -.-> B
    G["README-DEV.md\nnf-quilt at 1.0.0"] -.-> E
```

<sub>Reviews (1): Last reviewed commit: ["Release 1.0.0"](https://github.com/quiltdata/nf-quilt/commit/c7e63def2b07110656cdf4b023e9a7462b7baafa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30280267)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->