### PR TITLE
Match provider to registered claim

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ tasks.named('check') {
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'
-    provider = 'Quilt Data'
+    provider = 'Quilt Data, Inc.'
     className = 'nextflow.quilt.QuiltPlugin'
     extensionPoints = [
         'nextflow.quilt.QuiltObserverFactory',


### PR DESCRIPTION
Tiny follow-up to the 1.0.0 release: the registry claim is under 'Quilt Data, Inc.' so build.gradle needs to match for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)