### PR TITLE
Fix #332: Disable FAIL_ON_EMPTY_BEANS for NF 25.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1] 2026-04-30
+
+- Disable Jackson `FAIL_ON_EMPTY_BEANS` so config serialization survives Nextflow 25.10.x dynamic process directive closures that transitively pull in `SecretsLoader$1` (#332)
+- Add `make bump [LEVEL=patch|minor|major]` target backed by `wf/bump-version.sh`
+
 ## [1.0.0] 2026-04-29
 
 - First release published to the [Nextflow Plugin Registry](https://registry.nextflow.io)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ S3_BASE = s3://$(WRITE_BUCKET)/$(PROJECT)
 REPORT ?= ./build/reports/tests/test/index.html
 
 .PHONY: all assemble clean test test-all check rebuild install package release verify fast \
-        coverage verifyCoverage \
+        coverage verifyCoverage bump \
         check-env pkg-test dyn-test s3-overlay s3-test s3-in s3-out \
         pkg-fail path-input deps refresh
 
@@ -57,6 +57,13 @@ check-env:
 
 rebuild:
 	./gradlew clean build --refresh-dependencies
+
+# make bump                 -> patch bump (default)
+# make bump LEVEL=minor     -> minor bump
+# make bump LEVEL=major     -> major bump
+LEVEL ?= patch
+bump:
+	./wf/bump-version.sh $(LEVEL)
 
 test-all: clean test
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 // Plugin version: bump here to release a new version.
-version = '1.0.0'
+version = '1.0.1'
 group = 'io.nextflow'
 
 dependencies {

--- a/src/main/groovy/nextflow/quilt/QuiltProduct.groovy
+++ b/src/main/groovy/nextflow/quilt/QuiltProduct.groovy
@@ -101,6 +101,7 @@ ${nextflow}
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
     private static final ObjectWriter OBJECT_WRITER = OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
     static String toJson(Object value) {
         String result = OBJECT_WRITER.writeValueAsString(value)

--- a/src/test/groovy/nextflow/quilt/QuiltProductTest.groovy
+++ b/src/test/groovy/nextflow/quilt/QuiltProductTest.groovy
@@ -114,6 +114,24 @@ class QuiltProductTest extends QuiltSpecification {
         !(json =~ /"start"\s*:\s*[0-9]/)
     }
 
+    void 'toJson serializes empty beans without failing'() {
+        // Regression test for #332: on Nextflow 25.10.x, dynamic process directive
+        // closures (e.g. `cpus = { task.attempt * 2 }`) transitively pull in the
+        // script binding's `secrets` field, an anonymous SecretsLoader$1 inner
+        // class with no bean properties. Without disabling FAIL_ON_EMPTY_BEANS,
+        // Jackson throws when serializing config/params/workflow JSON.
+        given:
+        Object emptyBean = new Object() { } // anonymous inner class, no properties
+        Map map = [process: [cpus: [variables: [secrets: emptyBean]]]]
+
+        when:
+        String json = QuiltProduct.toJson(map)
+
+        then:
+        noExceptionThrown()
+        json.contains('"secrets"')
+    }
+
     void 'should generate solid string for timestamp from now'() {
         when:
         def now = QuiltProduct.now()

--- a/wf/bump-version.sh
+++ b/wf/bump-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LEVEL="${1:-patch}"
+case "$LEVEL" in
+    patch|minor|major) ;;
+    *) echo "Usage: $0 [patch|minor|major]" >&2; exit 1 ;;
+esac
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FILE="$ROOT/build.gradle"
+
+OLD="$(grep "^version" "$FILE" | head -1 | awk -F"'" '{ print $2 }')"
+if [[ ! "$OLD" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    echo "Cannot parse semver from '$OLD' in $FILE" >&2
+    exit 1
+fi
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+case "$LEVEL" in
+    patch) PATCH=$((PATCH + 1)) ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+esac
+NEW="${MAJOR}.${MINOR}.${PATCH}"
+
+sed -i.bak "s/^version = '${OLD}'\$/version = '${NEW}'/" "$FILE"
+rm "$FILE.bak"
+
+cd "$ROOT"
+git add build.gradle
+git commit -m "Bump version: ${OLD} -> ${NEW}"
+
+echo "Bumped $OLD -> $NEW and committed."


### PR DESCRIPTION
## Summary

- Disable `SerializationFeature.FAIL_ON_EMPTY_BEANS` on the shared Jackson `ObjectMapper` so `writeMapToPackage.toJson` survives Nextflow 25.10.x configs containing dynamic process directive closures (e.g. `cpus = { task.attempt * 2 }`) that transitively pull in the script binding's `SecretsLoader$1` field.
- Add a regression test in `QuiltProductTest` that nests an anonymous-class object inside the config map and confirms `toJson` does not throw.
- Add `make bump [LEVEL=patch|minor|major]` (default patch) backed by `wf/bump-version.sh`, which rewrites `version` in `build.gradle` and commits.
- Bump to 1.0.1, pre-publish `nf-quilt/dest-1.0.1` to `udp-spec`, update CHANGELOG.

Closes #332.

## Test plan

- [x] `./gradlew check` passes (test + jacoco coverage gate)
- [x] Verified the new regression test fails on `main`'s `ObjectMapper` and passes with `FAIL_ON_EMPTY_BEANS` disabled
- [x] `make pkg-test WRITE_BUCKET=udp-spec` published `nf-quilt/dest-1.0.1` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a serialization crash introduced in Nextflow 25.10.x where dynamic process directive closures (e.g. `cpus = { task.attempt * 2 }`) transitively pull in `SecretsLoader$1` — an anonymous inner class with no bean properties — causing Jackson to throw when `toJson` is called. The fix disables `SerializationFeature.FAIL_ON_EMPTY_BEANS` on the shared `ObjectMapper`, accompanied by a targeted regression test, a `make bump` convenience target, and a version bump to 1.0.1.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is minimal and correct, with only a trivial style issue in the new shell script.

All P2-only findings — the sole issue is an unescaped dot in the sed regex inside `bump-version.sh`, which is extremely unlikely to cause a false match in practice. The main bug fix and regression test are correct and well-scoped.

wf/bump-version.sh (minor sed escaping issue on line 29)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/groovy/nextflow/quilt/QuiltProduct.groovy | Adds `.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)` to the shared ObjectMapper — correct targeted fix for NF 25.10.x closure serialization failure. |
| src/test/groovy/nextflow/quilt/QuiltProductTest.groovy | Adds regression test verifying `toJson` handles anonymous inner classes without throwing; assertion and Spock structure are correct. |
| wf/bump-version.sh | New version-bump helper script; minor: version string used unescaped as a sed regex, so dots act as wildcards (unlikely to cause real problems but not strictly correct). |
| Makefile | Adds `bump` phony target delegating to `wf/bump-version.sh` with configurable `LEVEL`; straightforward and correct. |
| build.gradle | Version bump from 1.0.0 to 1.0.1 — matches CHANGELOG and PR intent. |
| CHANGELOG.md | 1.0.1 release notes added with accurate description of the fix and new `make bump` target. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["NF 25.10.x config map\n(contains dynamic closures)"] --> B["QuiltProduct.writeMapToPackage"]
    B --> C["toJson(map)"]
    C --> D["OBJECT_WRITER.writeValueAsString(value)"]
    D --> E{FAIL_ON_EMPTY_BEANS?}
    E -- "enabled (main)" --> F["JsonMappingException\nSecretsLoader$1 has no properties"]
    E -- "disabled (this PR)" --> G["Serializes empty bean as {}"]
    G --> H["JSON string written to package"]
```

<sub>Reviews (1): Last reviewed commit: ["Update CHANGELOG for 1.0.1"](https://github.com/quiltdata/nf-quilt/commit/657a2094a00dbd8f4955cff0845a15c6cd6b7d89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30405457)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->