### PR TITLE
Add make tag target for GitHub release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ S3_BASE = s3://$(WRITE_BUCKET)/$(PROJECT)
 REPORT ?= ./build/reports/tests/test/index.html
 
 .PHONY: all assemble clean test test-all check rebuild install package release verify fast \
-        coverage verifyCoverage bump \
+        coverage verifyCoverage bump tag \
         check-env pkg-test dyn-test s3-overlay s3-test s3-in s3-out \
         pkg-fail path-input deps refresh
 
@@ -64,6 +64,11 @@ rebuild:
 LEVEL ?= patch
 bump:
 	./wf/bump-version.sh $(LEVEL)
+
+# Tag the current build.gradle version and create a GitHub release
+# using the matching CHANGELOG section as release notes.
+tag:
+	./wf/tag-release.sh
 
 test-all: clean test
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ install: assemble
 package:
 	./gradlew packagePlugin
 
-release:
+release: tag
 	./gradlew releasePlugin
 
 #

--- a/wf/bump-version.sh
+++ b/wf/bump-version.sh
@@ -26,7 +26,7 @@ case "$LEVEL" in
 esac
 NEW="${MAJOR}.${MINOR}.${PATCH}"
 
-sed -i.bak "s/^version = '${OLD}'\$/version = '${NEW}'/" "$FILE"
+sed -i.bak "s/^version = '${OLD//./\\.}'\$/version = '${NEW}'/" "$FILE"
 rm "$FILE.bak"
 
 cd "$ROOT"

--- a/wf/tag-release.sh
+++ b/wf/tag-release.sh
@@ -26,18 +26,20 @@ if [[ "$BRANCH" != "main" || "$HEAD_SHA" != "$MAIN_SHA" ]]; then
     echo "(dry-run: continuing anyway)" >&2
 fi
 
-if git rev-parse "$VERSION" >/dev/null 2>&1; then
+if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
     echo "Tag $VERSION already exists" >&2
     [[ $DRY_RUN -eq 1 ]] || exit 1
 fi
 
-NOTES="$(awk -v v="$VERSION" '
+# Escape dots so awk treats the version literally (1.0.1 must not match 1X0Y1).
+ESCAPED_VERSION="${VERSION//./\\.}"
+NOTES="$(awk -v v="$ESCAPED_VERSION" '
     $0 ~ "^## \\[" v "\\]" { found=1; next }
     found && /^## \[/ { exit }
     found { print }
 ' CHANGELOG.md)"
 
-if [[ -z "${NOTES// }" ]]; then
+if [[ -z "$(printf %s "$NOTES" | tr -d '[:space:]')" ]]; then
     echo "No CHANGELOG section found for [$VERSION]" >&2
     exit 1
 fi
@@ -57,5 +59,12 @@ fi
 
 git tag -a "$VERSION" -m "Release $VERSION"
 git push origin "$VERSION"
-gh release create "$VERSION" --title "Version $VERSION" --notes "$NOTES"
+
+# Roll back the tag if release creation fails so we don't leave a half-released state.
+if ! gh release create "$VERSION" --title "Version $VERSION" --notes "$NOTES"; then
+    echo "gh release create failed; rolling back tag $VERSION" >&2
+    git push origin --delete "$VERSION" || true
+    git tag -d "$VERSION" || true
+    exit 1
+fi
 echo "Tagged and released $VERSION"

--- a/wf/tag-release.sh
+++ b/wf/tag-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="$(grep "^version" build.gradle | head -1 | awk -F"'" '{ print $2 }')"
+if [[ -z "$VERSION" ]]; then
+    echo "Could not parse version from build.gradle" >&2
+    exit 1
+fi
+
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    echo "Tag $VERSION already exists" >&2
+    exit 1
+fi
+
+# Extract the CHANGELOG section for this version (between its header and the next ## header).
+NOTES="$(awk -v v="$VERSION" '
+    $0 ~ "^## \\[" v "\\]" { found=1; next }
+    found && /^## \[/ { exit }
+    found { print }
+' CHANGELOG.md)"
+
+if [[ -z "${NOTES// }" ]]; then
+    echo "No CHANGELOG section found for [$VERSION]" >&2
+    exit 1
+fi
+
+git tag -a "$VERSION" -m "Release $VERSION"
+git push origin "$VERSION"
+
+gh release create "$VERSION" --title "Version $VERSION" --notes "$NOTES"
+echo "Tagged and released $VERSION"

--- a/wf/tag-release.sh
+++ b/wf/tag-release.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+fi
+
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
@@ -10,12 +15,22 @@ if [[ -z "$VERSION" ]]; then
     exit 1
 fi
 
-if git rev-parse "$VERSION" >/dev/null 2>&1; then
-    echo "Tag $VERSION already exists" >&2
-    exit 1
+# Refuse to tag from anywhere but main at origin/main's HEAD.
+git fetch origin main --quiet
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+HEAD_SHA="$(git rev-parse HEAD)"
+MAIN_SHA="$(git rev-parse origin/main)"
+if [[ "$BRANCH" != "main" || "$HEAD_SHA" != "$MAIN_SHA" ]]; then
+    echo "Refusing to tag: must be on main at origin/main (currently $BRANCH @ ${HEAD_SHA:0:7}, origin/main @ ${MAIN_SHA:0:7})" >&2
+    [[ $DRY_RUN -eq 1 ]] || exit 1
+    echo "(dry-run: continuing anyway)" >&2
 fi
 
-# Extract the CHANGELOG section for this version (between its header and the next ## header).
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    echo "Tag $VERSION already exists" >&2
+    [[ $DRY_RUN -eq 1 ]] || exit 1
+fi
+
 NOTES="$(awk -v v="$VERSION" '
     $0 ~ "^## \\[" v "\\]" { found=1; next }
     found && /^## \[/ { exit }
@@ -27,8 +42,20 @@ if [[ -z "${NOTES// }" ]]; then
     exit 1
 fi
 
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "=== DRY RUN ==="
+    echo "Version: $VERSION"
+    echo "HEAD:    ${HEAD_SHA:0:7} ($BRANCH)"
+    echo "--- Release notes ---"
+    echo "$NOTES"
+    echo "--- Would run ---"
+    echo "git tag -a $VERSION -m 'Release $VERSION'"
+    echo "git push origin $VERSION"
+    echo "gh release create $VERSION --title 'Version $VERSION' --notes <notes above>"
+    exit 0
+fi
+
 git tag -a "$VERSION" -m "Release $VERSION"
 git push origin "$VERSION"
-
 gh release create "$VERSION" --title "Version $VERSION" --notes "$NOTES"
 echo "Tagged and released $VERSION"


### PR DESCRIPTION
## Summary

- Add `wf/tag-release.sh` that reads the current `version` from `build.gradle`, extracts the matching `## [x.y.z]` section from `CHANGELOG.md`, creates an annotated git tag, pushes it, and runs `gh release create` with those notes.
- Wire it up as `make tag`.

Complements `make release` (publishes to the Nextflow Plugin Registry) by handling the separate GitHub-release step.

## Test plan

- [x] Verified the awk CHANGELOG extraction returns the 1.0.1 bullets
- [ ] Run `make tag` after merge to cut the 1.0.1 GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `wf/tag-release.sh` (wired as `make tag`) which reads the version from `build.gradle`, extracts the matching `CHANGELOG.md` section, creates an annotated git tag, pushes it, and calls `gh release create`.

- **Partial-failure gap (P1):** `git push origin "$VERSION"` runs before `gh release create`. If the GitHub release step fails (auth error, release already exists, network timeout), the tag is already live on the remote but no release is attached. The "tag already exists" guard then prevents any re-run, leaving the repo in a half-released state without rollback.

<h3>Confidence Score: 3/5</h3>

Needs the partial-failure rollback fixed before running in production; the remaining issues are minor.

One P1 (tag pushed without rollback on release-creation failure) plus three P2s (ref scoping, awk dot escaping, whitespace check) pulls the score below the P1 ceiling of 4.

wf/tag-release.sh — specifically lines 30-33 around tag push / release create ordering

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| wf/tag-release.sh | New script to tag and publish a GitHub release; has a P1 partial-failure risk (tag pushed before release creation, no rollback), plus P2 issues with ref scoping, awk regex dot escaping, and incomplete whitespace trimming. |
| Makefile | Adds `tag` to .PHONY and wires it to `wf/tag-release.sh`; straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as tag-release.sh
    participant FS as Filesystem
    participant Git as Git (local+remote)
    participant GH as GitHub Releases

    Dev->>Script: make tag
    Script->>FS: grep version from build.gradle
    FS-->>Script: VERSION
    Script->>Git: git rev-parse refs/tags/VERSION
    Git-->>Script: not found → proceed
    Script->>FS: awk extract CHANGELOG section
    FS-->>Script: NOTES
    Script->>Git: git tag -a VERSION
    Script->>Git: git push origin VERSION
    Git-->>Script: tag pushed ✓
    Script->>GH: gh release create VERSION --notes NOTES
    GH-->>Script: release created ✓ (or ✗ → tag stranded)
    Script->>Dev: echo "Tagged and released VERSION"
```

<sub>Reviews (1): Last reviewed commit: ["Make release depend on tag"](https://github.com/quiltdata/nf-quilt/commit/539ab28d0225bab57a6423a0b622de0f0e624381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30405953)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->