### PR TITLE
Export Makefile vars so .env reaches gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 sinclude .env # create from example.env
-export NPR_API_KEY WRITE_BUCKET
+# Export to subprocesses (gradle, nextflow). Only export WRITE_BUCKET when
+# .env actually sets it; the integration tests use env.WRITE_BUCKET == null
+# as their @IgnoreIf signal, so a placeholder default would unmask them in CI.
+export NPR_API_KEY
+ifneq ($(strip $(WRITE_BUCKET)),)
+export WRITE_BUCKET
+endif
 PROJECT ?= nf-quilt
-WRITE_BUCKET ?= write-bucket-not-set
 FRAGMENT ?= &path=.
 QUERY ?= ?Name=$(USER)&Owner=Kevin+Moore&Date=2023-03-07&Type=CRISPR&Notebook+URL=http%3A%2F%2Fexample.com
 VERSION ?= $(shell grep "^version" build.gradle | head -1 | awk -F"'" '{ print $$2 }')

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 sinclude .env # create from example.env
+export
 PROJECT ?= nf-quilt
 WRITE_BUCKET ?= write-bucket-not-set
 FRAGMENT ?= &path=.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 sinclude .env # create from example.env
-export
+export NPR_API_KEY WRITE_BUCKET
 PROJECT ?= nf-quilt
 WRITE_BUCKET ?= write-bucket-not-set
 FRAGMENT ?= &path=.


### PR DESCRIPTION
## Summary

`sinclude .env` loaded `NPR_API_KEY` and `WRITE_BUCKET` as Make variables but did not export them to recipe subprocesses, so `./gradlew releasePlugin` invoked via `make release` failed with "Registry API key must be configured...". Adding a bare `export` directive exports all Make variables to children.

## Test plan

- [x] Verified `make release` previously failed at `releasePluginToRegistry` with NPR_API_KEY missing
- [x] Verified `set -a; . ./.env; ./gradlew releasePlugin` succeeds (used to actually publish 1.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `make release` failing at `releasePluginToRegistry` by adding a bare `export` directive after `sinclude .env`, which causes GNU Make to forward all Make variables (including `NPR_API_KEY` loaded from `.env`) into the environment of recipe subprocesses like `./gradlew releasePlugin`. The fix correctly solves the stated problem, though exporting every variable is broader than the minimum needed.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix is correct and the only finding is a style-level concern about export scope.

Single P2 finding (bare `export` is broader than necessary); no logic errors or security issues present.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Makefile | Adds bare `export` directive so variables loaded from `.env` via `sinclude` are forwarded to recipe subprocesses (e.g. `./gradlew releasePlugin`); fix is correct but exports all Make variables globally rather than only the needed credentials. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Make as GNU Make
    participant Env as .env file
    participant Gradle as ./gradlew

    Dev->>Make: make release
    Make->>Env: sinclude .env (loads NPR_API_KEY, WRITE_BUCKET)
    Note over Make: export (all vars → subprocess env)
    Make->>Make: run `tag` prerequisite
    Make->>Gradle: releasePlugin (env contains NPR_API_KEY)
    Gradle-->>Dev: Plugin published ✓
```

<sub>Reviews (1): Last reviewed commit: ["Export Makefile variables so .env propag..."](https://github.com/quiltdata/nf-quilt/commit/c988438eae5c3d53851afa509c16184b42328cfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30407531)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->